### PR TITLE
Improving Killaura

### DIFF
--- a/src/main/java/me/rhys/client/module/combat/aura/Aura.java
+++ b/src/main/java/me/rhys/client/module/combat/aura/Aura.java
@@ -8,6 +8,8 @@ import me.rhys.base.module.Module;
 import me.rhys.base.module.data.Category;
 import me.rhys.base.module.setting.manifest.Clamp;
 import me.rhys.base.module.setting.manifest.Name;
+import me.rhys.base.util.RotationUtil;
+import me.rhys.base.util.vec.Vec2f;
 import me.rhys.client.module.combat.aura.modes.Single;
 import me.rhys.client.module.combat.criticals.Criticals;
 import net.minecraft.entity.Entity;
@@ -17,6 +19,9 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.EntityMob;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 
 public class Aura extends Module {
     public Aura(String name, String description, Category category, int keyCode) {
@@ -32,9 +37,8 @@ public class Aura extends Module {
     @Clamp(min = 1, max = 9)
     public double reach = 4.25f;
 
-    @Name("LookReach")
-    @Clamp(min = 1, max = 12)
-    public double lookReach = 6f;
+    @Name("rayCheck")
+    public boolean rayCheck = true;
 
     @Name("Monsters")
     public boolean monsters = false;
@@ -95,7 +99,21 @@ public class Aura extends Module {
     private boolean isEntityValid(Entity entity) {
         if (mc.thePlayer.isEntityEqual(entity)) return false;
 
-        if (mc.thePlayer.getDistanceToEntity(entity) >= lookReach) return false;
+        //Checking reach distance
+        if(rayCheck) {
+            final AxisAlignedBB targetBox = entity.getEntityBoundingBox();
+            final Vec2f rotation = RotationUtil.getRotations(entity);
+
+            final Vec3 origin = mc.thePlayer.getPositionEyes(1.0f);
+            Vec3 look = entity.getVectorForRotation(rotation.y, rotation.x);
+
+            look = origin.addVector(look.xCoord * reach,
+                    look.yCoord * reach,
+                    look.zCoord * reach);
+            MovingObjectPosition collision = targetBox.calculateIntercept(origin, look);
+
+            if (collision == null) return false;
+        } else if (mc.thePlayer.getDistanceToEntity(entity) >= reach) return false;
 
         if (Lite.FRIEND_MANAGER.getFriend(entity.getName()) != null) return false;
 

--- a/src/main/java/me/rhys/client/module/combat/aura/Aura.java
+++ b/src/main/java/me/rhys/client/module/combat/aura/Aura.java
@@ -32,6 +32,10 @@ public class Aura extends Module {
     @Clamp(min = 1, max = 9)
     public double reach = 4.25f;
 
+    @Name("LookReach")
+    @Clamp(min = 1, max = 12)
+    public double lookReach = 6f;
+
     @Name("Monsters")
     public boolean monsters = false;
 
@@ -91,7 +95,7 @@ public class Aura extends Module {
     private boolean isEntityValid(Entity entity) {
         if (mc.thePlayer.isEntityEqual(entity)) return false;
 
-        if (mc.thePlayer.getDistanceToEntity(entity) >= reach) return false;
+        if (mc.thePlayer.getDistanceToEntity(entity) >= lookReach) return false;
 
         if (Lite.FRIEND_MANAGER.getFriend(entity.getName()) != null) return false;
 

--- a/src/main/java/me/rhys/client/module/combat/aura/modes/Single.java
+++ b/src/main/java/me/rhys/client/module/combat/aura/modes/Single.java
@@ -1,6 +1,5 @@
 package me.rhys.client.module.combat.aura.modes;
 
-import lombok.extern.slf4j.Slf4j;
 import me.rhys.base.event.Event;
 import me.rhys.base.event.data.EventTarget;
 import me.rhys.base.event.impl.player.PlayerMotionEvent;
@@ -13,9 +12,6 @@ import me.rhys.base.util.vec.Vec2f;
 import me.rhys.client.module.combat.aura.Aura;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.play.client.C02PacketUseEntity;
-import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.MovingObjectPosition;
-import net.minecraft.util.Vec3;
 
 public class Single extends ModuleMode<Aura> {
     public Single(String name, Aura parent) {

--- a/src/main/java/me/rhys/client/module/combat/aura/modes/Single.java
+++ b/src/main/java/me/rhys/client/module/combat/aura/modes/Single.java
@@ -50,27 +50,6 @@ public class Single extends ModuleMode<Aura> {
     }
 
     void swing(Entity target) {
-        final AxisAlignedBB targetBox = target.getEntityBoundingBox();
-
-        Vec3 origin = mc.thePlayer.getPositionEyes(1.0f);
-        Vec3 look = mc.thePlayer.getLook(1.0f);
-
-        look = origin.addVector(look.xCoord * getParent().reach,
-                look.yCoord * getParent().reach,
-                look.zCoord * getParent().reach);
-        MovingObjectPosition collision = targetBox.calculateIntercept(origin, look);
-
-        if(collision == null) {
-            System.out.println("Did not collide with the player.");
-            return;
-        }
-
-        double distance = collision.hitVec.distanceTo(origin);
-        if(distance > getParent().reach) {
-            System.out.printf("The target is too far (%.3f>-%.3f)%n", distance, getParent().reach);
-            return;
-        }
-
         double aps = (parent.cps + MathUtil.randFloat(MathUtil.randFloat(1, 3), MathUtil.randFloat(3, 5)));
 
         if (this.attackTimer.hasReached(1000L / aps)) {

--- a/src/main/java/me/rhys/client/module/combat/aura/modes/Single.java
+++ b/src/main/java/me/rhys/client/module/combat/aura/modes/Single.java
@@ -1,5 +1,6 @@
 package me.rhys.client.module.combat.aura.modes;
 
+import lombok.extern.slf4j.Slf4j;
 import me.rhys.base.event.Event;
 import me.rhys.base.event.data.EventTarget;
 import me.rhys.base.event.impl.player.PlayerMotionEvent;
@@ -12,6 +13,9 @@ import me.rhys.base.util.vec.Vec2f;
 import me.rhys.client.module.combat.aura.Aura;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.play.client.C02PacketUseEntity;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 
 public class Single extends ModuleMode<Aura> {
     public Single(String name, Aura parent) {
@@ -46,6 +50,27 @@ public class Single extends ModuleMode<Aura> {
     }
 
     void swing(Entity target) {
+        final AxisAlignedBB targetBox = target.getEntityBoundingBox();
+
+        Vec3 origin = mc.thePlayer.getPositionEyes(1.0f);
+        Vec3 look = mc.thePlayer.getLook(1.0f);
+
+        look = origin.addVector(look.xCoord * getParent().reach,
+                look.yCoord * getParent().reach,
+                look.zCoord * getParent().reach);
+        MovingObjectPosition collision = targetBox.calculateIntercept(origin, look);
+
+        if(collision == null) {
+            System.out.println("Did not collide with the player.");
+            return;
+        }
+
+        double distance = collision.hitVec.distanceTo(origin);
+        if(distance > getParent().reach) {
+            System.out.printf("The target is too far (%.3f>-%.3f)%n", distance, getParent().reach);
+            return;
+        }
+
         double aps = (parent.cps + MathUtil.randFloat(MathUtil.randFloat(1, 3), MathUtil.randFloat(3, 5)));
 
         if (this.attackTimer.hasReached(1000L / aps)) {


### PR DESCRIPTION
- The reach distance will now be correct when using the Killaura. So if the reach max is set to 4.25, it will reach 4.25. This is optional with rayCheck setting enabled.
- Killaura will not attack unless the player is looking at target if the rotation may be slightly broken. Function will not work if rayCheck is disabled.